### PR TITLE
Fix handling of border-radius with only one value (MDL-61496)

### DIFF
--- a/src/MoodleHQ/RTLCSS/RTLCSS.php
+++ b/src/MoodleHQ/RTLCSS/RTLCSS.php
@@ -270,17 +270,19 @@ class RTLCSS {
                     $groups = [$value];
                 }
                 foreach ($groups as $group) {
-                    $values = $group->getListComponents();
-                    switch (count($values)) {
-                        case 2:
-                            $group->setListComponents(array_reverse($values));
-                            break;
-                        case 3:
-                            $group->setListComponents([$values[1], $values[0], $values[1], $values[2]]);
-                            break;
-                        case 4:
-                            $group->setListComponents([$values[1], $values[0], $values[3], $values[2]]);
-                            break;
+                    if ($group instanceof RuleValueList) {
+                        $values = $group->getListComponents();
+                        switch (count($values)) {
+                            case 2:
+                                $group->setListComponents(array_reverse($values));
+                                break;
+                            case 3:
+                                $group->setListComponents([$values[1], $values[0], $values[1], $values[2]]);
+                                break;
+                            case 4:
+                                $group->setListComponents([$values[1], $values[0], $values[3], $values[2]]);
+                                break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This was breaking RTL in the OU theme. This fix works there. Because of issue #3, I cannot easily add a unit test (but I would if the tests passed).

Anyway, please could this be merged (along with the other pull request that has been sitting around for months.

Then, please, could this library be updated in Moodle core - these are bug fixes, so should be done on all stable branches.